### PR TITLE
fix: Scoring logic, added correctness threshold

### DIFF
--- a/utils/calculateScore.js
+++ b/utils/calculateScore.js
@@ -1,3 +1,6 @@
+// min passed_ratio required to earn the submit-count/time bonuses in Round 1 & 2
+const CORRECTNESS_THRESHOLD = 0.8;
+
 //submits are the number of submits for a particular questions NOT ROUND
 export const ScoreRound0 = (totalcases, passedcases, submits) => {
     var score = 0;
@@ -44,11 +47,13 @@ export const ScoreRound1 = (time_left, totalcases, passedcases, difficulty, win,
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (submits <= 3) {
-        current_score += (max_score * 0.1);
+    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
+        if (submits <= 3) {
+            current_score += (max_score * 0.1);
+        }
+        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        current_score += time_formula;
     }
-    var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
-    current_score += time_formula;
 
     return current_score;
 };
@@ -73,11 +78,13 @@ export const ScoreRound2 = (time_left, totalcases, passedcases, difficulty, win,
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (submits <= 3) {
-        current_score += (max_score * 0.1);
+    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
+        if (submits <= 3) {
+            current_score += (max_score * 0.1);
+        }
+        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        current_score += time_formula;
     }
-    var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
-    current_score += time_formula;
     if (iselite) {
         current_score *= 0.75;
     }


### PR DESCRIPTION
## Description

Fixes a scoring exploit in Round 1 and Round 2 where submissions could earn a large chunk of score without actually solving the problem. `ScoreRound1` and `ScoreRound2` previously awarded a "submitted ≤3 times" bonus (10% of max score) and a submission-speed bonus (20% of max score) **unconditionally** — regardless of how many test cases actually passed. This meant a completely wrong (or hardcoded) submission could still earn ~30% of the max score just by being submitted quickly and with few attempts.

This PR gates both bonuses behind a minimum 80% pass ratio (`CORRECTNESS_THRESHOLD`). Submissions passing fewer than 80% of test cases now only earn the honest, proportional pass-ratio credit — no bonus padding. Submissions at or above 80% behave exactly as before.

No function signatures changed, so the only caller (`routes/submit.routes.js`) needed no updates. `ScoreRound0` and `ScoreRound3` were left untouched since they don't have this issue (already purely proportional).

**Before → After (R1_EASY, max_score=200):**
| Scenario | Before | After |
|---|---|---|
| 0% pass, 1 submit, instant submit | ~60 | 0 |
| 79% pass, 1 submit, instant submit | ~107 | ~47 (proportional only) |
| 80% pass, 1 submit, instant submit | ~108 | ~108 (unchanged) |
| 100% pass + win | 200 | 200 (unchanged) |

---

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other

---

## Related Issues

Closes #21

---

## Checklist

- [x] Code follows project guidelines
- [x] No secrets committed
- [ ] Documentation updated if required
- [ ] Tested locally
