### PR TITLE
Prradyun56/fix scoring bonus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,14 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
 
           script: |
+            set -e
+
             cd /home/ubuntu/battlecode-backend
 
             git fetch origin
             git reset --hard origin/gravitas-26
+
+            docker builder prune -af
 
             docker compose up -d --build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy Backend to EC2
+
+on:
+  push:
+    branches:
+      - gravitas-26
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.2.0
+
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+
+          script: |
+            cd /home/ubuntu/battlecode-backend
+
+            git fetch origin
+            git reset --hard origin/gravitas-26
+
+            docker compose up -d --build
+
+            docker builder prune -f

--- a/routes/submit.routes.js
+++ b/routes/submit.routes.js
@@ -23,6 +23,9 @@ const JUDGE0_API_URL = process.env.JUDGE0_API_URL;
 const JUDGE0_API_KEY = null;
 const HARD_API_TIMEOUT_MS = 60_000; // 60 seconds
 const POLL_INTERVAL_MS = 1000;
+// Slack allowed past a Round 2 match/bounty deadline so a submission fired on
+// the buzzer isn't rejected for network latency.
+const SESSION_GRACE_MS = 30_000; // 30 seconds
 
 const LANGUAGE_ID_MAP = {
   cpp: 105,
@@ -138,6 +141,7 @@ router.post("/run", async (req, res) => {
  * POST /submit
  */
 router.post("/submit", verifyAuthToken, async (req, res) => {
+  let submitLockKey = null;
   try {
     console.log("🔵 [SUBMIT] New submission request received");
 
@@ -188,6 +192,17 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
       });
     }
 
+    // Prevent concurrent duplicate submissions for the same user+problem from
+    // racing past the existingSubmission read and double-counting eventScore.
+    submitLockKey = `submit:lock:${userId}:${problemId}`;
+    const lockAcquired = await redis.set(submitLockKey, "1", "NX", "EX", 90);
+    if (!lockAcquired) {
+      submitLockKey = null; // not ours to release
+      return res.status(429).json({
+        error: "A submission for this problem is already being processed. Please wait for it to finish.",
+      });
+    }
+
     const language_id = LANGUAGE_ID_MAP[language.toLowerCase()];
     if (!language_id) {
       console.log("❌ [SUBMIT] Unsupported language:", language);
@@ -227,6 +242,100 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
         .status(400)
         .json({ error: "Problem does not belong to specified round" });
     }
+
+    // The round must actually be running. Without this, Round 0 and Round 3
+    // problems could be submitted before their round opened or long after it
+    // closed (Rounds 1 & 2 were incidentally protected by needing a live
+    // match/bounty). Admins bypass so they can smoke-test a round any time.
+    const roundState = await prisma.round.findUnique({
+      where: { roundNumber },
+      select: { status: true },
+    });
+
+    if (user.role !== "ADMIN" && roundState?.status !== "IN_PROGRESS") {
+      console.log("❌ [SUBMIT] Round not in progress:", roundNumber, roundState?.status);
+      return res.status(403).json({
+        error: `Round ${roundNumber} is not currently accepting submissions.`,
+        roundStatus: roundState?.status || "UNKNOWN",
+      });
+    }
+
+    // Capture any live Round 1/2 session BEFORE the code goes to Judge0.
+    // Judging takes up to 60s, and the opponent may finish in that window,
+    // which deletes the session key. Previously that made an honest
+    // submission score 0 (Round 1) or fail outright with a 400 (Round 2).
+    // The session is re-checked after judging, but only to decide the win
+    // bonus -- partial credit is now always kept.
+    let activeMatch = null;   // Round 1 match
+    let round2Match = null;   // Round 2 challenge match
+    const now = Date.now();
+
+    if (roundNumber === 1) {
+      const keys = getRound1RedisKeys();
+      const allMatchesStr = await redis.hgetall(keys.matches);
+
+      for (const matchId in allMatchesStr) {
+        const match = JSON.parse(allMatchesStr[matchId]);
+        if (match.players.includes(userId) && match.problemId === problemId) {
+          activeMatch = match;
+          break;
+        }
+      }
+
+      if (!activeMatch) {
+        console.warn(`[Round 1] No active match found for user ${userId}`);
+      }
+    } else if (roundNumber === 2) {
+      if (context?.type === "match") {
+        // Verify the caller is actually a participant in a live Round 2 match
+        // for this exact problem, mirroring the Round 1 activeMatch check.
+        const matchDataStr = context.contextId
+          ? await redis.get(`round2:match:${context.contextId}`)
+          : null;
+        const matchData = matchDataStr ? JSON.parse(matchDataStr) : null;
+
+        if (
+          !matchData ||
+          ![matchData.challengerId, matchData.eliteId].includes(userId) ||
+          matchData.question?.id !== problemId
+        ) {
+          console.warn(`[Round 2] No active match found for user ${userId} on problem ${problemId}`);
+          return res.status(400).json({ error: "No active match found for this submission" });
+        }
+
+        // Round 2 has no server-side match timer, so the deadline is enforced
+        // here instead. Small grace period so someone who hits submit right on
+        // the buzzer isn't punished for network latency.
+        if (matchData.endTime && now > matchData.endTime + SESSION_GRACE_MS) {
+          console.warn(`[Round 2] Match ${context.contextId} already ended for user ${userId}`);
+          return res.status(400).json({ error: "This match has already ended." });
+        }
+
+        round2Match = matchData;
+      } else if (context?.type === "bounty") {
+        // Verify the caller actually has a live bounty session open for this
+        // problem before scoring anything.
+        const bountySession = await redis.hgetall(`round2:bounty:${userId}:${problemId}`);
+        if (!bountySession || bountySession.status !== "active") {
+          console.warn(`[Round 2] No active bounty session found for user ${userId} on problem ${problemId}`);
+          return res.status(400).json({ error: "No active bounty session found for this submission" });
+        }
+
+        const bountyEndTime = parseInt(bountySession.endTime);
+        if (bountyEndTime && now > bountyEndTime + SESSION_GRACE_MS) {
+          console.warn(`[Round 2] Bounty session expired for user ${userId} on problem ${problemId}`);
+          return res.status(400).json({ error: "This bounty session has already ended." });
+        }
+      } else {
+        console.warn(
+          `[Round 2] Unknown or missing context type: ${context?.type}`
+        );
+      }
+    }
+
+    // Timestamp used for all time-bonus maths. Captured before judging so a
+    // slow Judge0 queue doesn't eat into the student's time bonus.
+    const submitReceivedAt = Date.now();
 
     const sampleTestCases = Array.isArray(problem.sampleTestCases)
       ? problem.sampleTestCases
@@ -315,17 +424,32 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
     const passedCount = results.filter((r) => r.status?.id === 3).length;
     const totalCount = allTestCases.length;
 
-    /** ✅ FINAL STATUS RESOLUTION (DO NOT CHANGE ORDER) */
+    /** ✅ FINAL STATUS RESOLUTION (ORDER MATTERS)
+     *
+     * `passedCount === totalCount` means Judge0 returned status.id 3 (Accepted)
+     * for EVERY test case, so the submission is correct by definition and must
+     * win over the compile_output/stderr heuristics below.
+     *
+     * Those two checks are text sniffing, not error detection: Judge0 puts
+     * compiler WARNINGS in compile_output (gcc/g++ do this constantly) and any
+     * leftover `cerr`/`console.error`/`print(file=sys.stderr)` debug line lands
+     * in stderr. Previously either one downgraded a fully-passing solution to
+     * COMPILATION_ERROR / RUNTIME_ERROR, which cost the student the Round 1/2
+     * win bonus and zeroed their bounty completion entirely.
+     *
+     * The explicit >2.0s check still runs first, so the stricter-than-Judge0
+     * local time limit is unchanged.
+     */
     if (submissionStatus === "TIME_LIMIT_EXCEEDED") {
       // already set
+    } else if (results.some((r) => parseFloat(r.time) > 2.0)) {
+      submissionStatus = "TIME_LIMIT_EXCEEDED";
+    } else if (passedCount === totalCount && totalCount > 0) {
+      submissionStatus = "ACCEPTED";
     } else if (results.some((r) => r.compile_output)) {
       submissionStatus = "COMPILATION_ERROR";
     } else if (results.some((r) => r.stderr)) {
       submissionStatus = "RUNTIME_ERROR";
-    } else if (results.some((r) => parseFloat(r.time) > 2.0)) {
-      submissionStatus = "TIME_LIMIT_EXCEEDED";
-    } else if (passedCount === totalCount) {
-      submissionStatus = "ACCEPTED";
     } else {
       submissionStatus = "WRONG_ANSWER";
     }
@@ -342,23 +466,35 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
       calculatedScore = ScoreRound0(totalCount, passedCount, executionCount);
       console.log("💯 [SUBMIT] Round 0 score calculated:", calculatedScore);
     } else if (roundNumber === 3) {
+      if (!user.qualifiedForR3) {
+        console.log("❌ [SUBMIT] User not qualified for Round 3:", userId);
+        return res.status(403).json({ error: "You are not qualified for Round 3" });
+      }
       calculatedScore = ScoreRound3(totalCount, passedCount, executionCount);
       console.log("💯 [SUBMIT] Round 3 score calculated:", calculatedScore);
     } else if (roundNumber === 1) {
-      const keys = getRound1RedisKeys();
-      const allMatchesStr = await redis.hgetall(keys.matches);
-
-      let activeMatch = null;
-      for (const matchId in allMatchesStr) {
-        const match = JSON.parse(allMatchesStr[matchId]);
-        if (match.players.includes(userId) && match.problemId === problemId) {
-          activeMatch = match;
-          break;
-        }
-      }
-
       if (activeMatch) {
-        const isWinner = submissionStatus === "ACCEPTED";
+        // The win bonus goes to the first correct solver only. Re-check the
+        // match here rather than trusting the copy captured before judging,
+        // since the opponent may have finished (or the clock run out) while
+        // Judge0 was working. The claim key makes "who was first" atomic so a
+        // simultaneous double-solve can't hand both players the bonus.
+        let isWinner = false;
+        if (submissionStatus === "ACCEPTED") {
+          const keys = getRound1RedisKeys();
+          const matchStillLive = await redis.hexists(keys.matches, activeMatch.id);
+          if (matchStillLive === 1) {
+            const claimed = await redis.set(
+              `round1:winner:${activeMatch.id}`,
+              userId,
+              "NX",
+              "EX",
+              3600
+            );
+            isWinner = !!claimed;
+          }
+        }
+
         const difficultyTimeMap = {
           R1_EASY: 15 * 60,
           R1_MEDIUM: 20 * 60,
@@ -366,7 +502,7 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
         };
         const totalTimeInSeconds = difficultyTimeMap[problem.difficulty] || 0;
         const elapsedTimeInSeconds =
-          (Date.now() - activeMatch.startTime) / 1000;
+          (submitReceivedAt - activeMatch.startTime) / 1000;
         const timeLeftInSeconds = Math.max(
           0,
           totalTimeInSeconds - elapsedTimeInSeconds
@@ -382,10 +518,8 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
         );
 
         if (isWinner) {
-          await handleMatchEnd(io, activeMatch.id, isWinner ? userId : null);
+          await handleMatchEnd(io, activeMatch.id, userId);
         }
-      } else {
-        console.warn(`[Round 1] No active match found for user ${userId}`);
       }
     } else if (roundNumber === 2) {
       // --- NEW: ROUND 2 SCORING LOGIC ---
@@ -393,45 +527,61 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
       const { matchEndHandler, bountyEndHandler } = getRound2Handlers();
 
       if (context?.type === "match") {
-        // Assuming 'match' is the challenge type
+        // round2Match was validated (participant, problem, deadline) before
+        // judging started -- see the session capture block above.
         const isElite = user.round2Role === "ELITE";
 
-        // NOTE: time_left isn't readily available here like in Round 1.
-        // Passing 0 for timeLeft, as score might be calculated within the handler with more context.
-        const timeLeftInSeconds = 0;
+        // The win bonus goes to the first correct solver only, claimed
+        // atomically so a simultaneous double-solve can't pay it twice.
+        let isWinner = false;
+        if (isCorrect) {
+          const matchStillLive = await redis.exists(`round2:match:${context.contextId}`);
+          if (matchStillLive === 1) {
+            const claimed = await redis.set(
+              `round2:winner:${context.contextId}`,
+              userId,
+              "NX",
+              "EX",
+              3600
+            );
+            isWinner = !!claimed;
+          }
+        }
+
+        // Real time remaining, from the match record written at match start.
+        // This was hardcoded to 0, which collapsed the intended 20% time
+        // component to a flat ~3.7 points for every player.
+        const timeLeftInSeconds = round2Match?.endTime
+          ? Math.max(0, (round2Match.endTime - submitReceivedAt) / 1000)
+          : 0;
 
         calculatedScore = ScoreRound2(
           timeLeftInSeconds,
           totalCount,
           passedCount,
           problem.difficulty,
-          isCorrect,
+          isWinner,
           isElite,
           executionCount // Passing executionCount as 'submits'
         );
 
-        if (isCorrect && matchEndHandler) {
+        if (isWinner && matchEndHandler) {
           await matchEndHandler(context.contextId, userId, "submission");
         }
       } else if (context?.type === "bounty") {
+        // The bounty session was validated (exists, active, not expired)
+        // before judging started -- see the session capture block above.
+
         // TODO: The `ScoreBounty` function expects "EASY", "MEDIUM", or "HARD".
         // The problem difficulty from the schema is 'R2_BOUNTY'. A mapping or a
         // new field on the Problem model is needed. Using "MEDIUM" as a placeholder.
         const bountyDifficulty = "MEDIUM";
 
-        const previouslySolvedSubmission = await prisma.submission.findFirst({
-          where: {
-            problemId: problemId,
-            status: "ACCEPTED",
-          },
-        });
-
-        const isSolved = !!previouslySolvedSubmission;
-
         calculatedScore = ScoreBounty(
           bountyDifficulty,
           executionCount,
-          isSolved
+          totalCount,
+          passedCount
         );
 
         if (bountyEndHandler) {
@@ -452,6 +602,14 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
         );
       }
     }
+
+    // User.eventScore is an Int column, but every formula with an exp() term
+    // (and most partial-credit paths) produces a float. Prisma rejects a
+    // fractional value on an Int field, so the eventScore update threw and the
+    // whole request 500'd after the submission row had already been written --
+    // the student's leaderboard score silently never moved. Rounding here
+    // keeps Submission.score and User.eventScore in agreement.
+    calculatedScore = Math.round(calculatedScore) || 0;
 
     let scoreImprovement = 0;
     let finalSubmission;
@@ -535,6 +693,10 @@ router.post("/submit", verifyAuthToken, async (req, res) => {
       error: "Failed to submit code",
       details: error.response?.data || error.message,
     });
+  } finally {
+    if (submitLockKey) {
+      await redis.del(submitLockKey).catch(() => {});
+    }
   }
 });
 

--- a/sockets/round2.handler.js
+++ b/sockets/round2.handler.js
@@ -289,7 +289,13 @@ export const round2Handler = (io, socket) => {
         if (loserParticipantStr) {
           const loserParticipant = JSON.parse(loserParticipantStr);
           if (loserParticipant.role === 'elite') {
-            await prisma.user.update({ where: { id: loserId }, data: { eventScore: { decrement: 2 } } });
+            // updateMany + gte guard keeps this atomic while flooring at 0 --
+            // a negative leaderboard score reads badly and also guarantees
+            // challenger status (and its 1.25x multiplier) as a side effect.
+            await prisma.user.updateMany({
+              where: { id: loserId, eventScore: { gte: 2 } },
+              data: { eventScore: { decrement: 2 } }
+            });
           }
         }
       }
@@ -1019,7 +1025,10 @@ export const round2Handler = (io, socket) => {
 
       const rejectCount = await redis.incr(keys.rejectCount(eliteId));
       if (rejectCount >= 3) {
-        await prisma.user.update({ where: { id: eliteId }, data: { eventScore: { decrement: 20 } } });
+        await prisma.user.updateMany({
+          where: { id: eliteId, eventScore: { gte: 20 } },
+          data: { eventScore: { decrement: 20 } }
+        });
         await redis.del(keys.rejectCount(eliteId));
         io.to(`user:${eliteId}`).emit('round2:info', { message: "You lost 20 points for rejecting 3 challenges." });
       }
@@ -1206,8 +1215,12 @@ export const round2Handler = (io, socket) => {
   socket.on("round2:challengeAccept", handleChallengeAccept);
   socket.on("round2:challengeReject", handleChallengeReject);
   socket.on("round2:reset", handleRound2Reset);
-  socket.on("round2:matchEnd", handleMatchEnd);
-  socket.on("round2:bountyend", handleBountyEnd);
+  // NOTE: handleMatchEnd/handleBountyEnd are intentionally NOT bound to client
+  // socket events. They are internal-only, invoked via matchEndHandler/
+  // bountyEndHandler (set below, exposed through getRound2Handlers()) after
+  // submit.routes.js validates a real correct submission, and internally from
+  // handleDisconnect. Binding them to socket.on let any client end a match or
+  // fabricate a bounty submission for any user with arbitrary results.
 
 };
 

--- a/utils/calculateScore.js
+++ b/utils/calculateScore.js
@@ -1,21 +1,69 @@
-// min passed_ratio required to earn the submit-count/time bonuses in Round 1 & 2
+// ---------------------------------------------------------------------------
+// Scoring tuning constants
+//
+// This event is a single ~12 hour sprint run by first-years, so the curves are
+// deliberately forgiving: partial work always pays, and the penalties for
+// iterating on a solution are small and recoverable.
+//
+// Every change here is bounded so that (a) no input scores LOWER than it did
+// under the previous revision, and (b) the per-problem maximum is unchanged.
+// That keeps the leaderboard shape and the admin-side qualification cutoffs
+// behaving the way they did before.
+// ---------------------------------------------------------------------------
+
+// passed_ratio at (or above) which the submit-count/time bonuses pay in full.
 const CORRECTNESS_THRESHOLD = 0.8;
+// passed_ratio below which those bonuses pay nothing at all. Between this and
+// CORRECTNESS_THRESHOLD they ramp linearly instead of switching on at a cliff.
+const BONUS_RAMP_START = 0.5;
+
+// Free submissions before the submit-count penalty/bonus-loss applies.
+const R0_FREE_SUBMITS = 4;
+const R12_FREE_SUBMITS = 5;
+const BOUNTY_FREE_SUBMITS = 5;
+
+// Time-bonus decay. Half-life = ln(2)/RATE. At 0.0008 that is ~14.4 minutes,
+// which actually spans a 15-25 minute problem window. (The previous 0.00256
+// gave a 4.5 minute half-life, so the time component was effectively dead.)
+const TIME_DECAY_RATE = 0.0008;
+
+/**
+ * How much of the "bonus" pool (submit-count + time) a given correctness ratio
+ * unlocks. Replaces the old hard `if (passed_ratio >= 0.8)` step, which made a
+ * single hidden test case worth ~30% of a problem.
+ *
+ * Returns 1.0 at/above CORRECTNESS_THRESHOLD, so anyone who cleared the old
+ * bar is unaffected; below it the bonuses fade out instead of vanishing.
+ */
+const bonusFactor = (passed_ratio) => {
+    if (passed_ratio >= CORRECTNESS_THRESHOLD) return 1;
+    if (passed_ratio <= BONUS_RAMP_START) return 0;
+    return (passed_ratio - BONUS_RAMP_START) / (CORRECTNESS_THRESHOLD - BONUS_RAMP_START);
+};
+
+const safeRatio = (totalcases, passedcases) => {
+    if (!totalcases || totalcases <= 0) return 0;
+    return Math.min(1, Math.max(0, passedcases / totalcases));
+};
 
 //submits are the number of submits for a particular questions NOT ROUND
 export const ScoreRound0 = (totalcases, passedcases, submits) => {
-    var score = 0;
-    var passed_ratio = passedcases / totalcases;
-    if (passed_ratio == 1) {
-        score += 50;
-    }
-    else {
-        score += 40 * passed_ratio;
+    var passed_ratio = safeRatio(totalcases, passedcases);
+
+    // Was: ratio === 1 ? 50 : 40 * ratio  -- a 26% jump for the last test case.
+    // Now the same 50 max, but partial work is paid proportionally.
+    var score = 45 * passed_ratio;
+    if (passed_ratio === 1) {
+        score += 5;
     }
 
-    if (submits > 2) {
-        score -= 10;
+    // Was: -10 after 2 submits. Because the best score is kept forever, that
+    // capped anyone who needed 3 attempts at 40/50 permanently.
+    if (submits > R0_FREE_SUBMITS) {
+        score -= 5;
     }
-    return score;
+
+    return Math.max(0, score);
 
 }; //450 max
 
@@ -26,7 +74,7 @@ export const ScoreRound1 = (time_left, totalcases, passedcases, difficulty, win,
     //time - 20%
     var total_time = 0;
     var max_score = 0;
-    var passed_ratio = passedcases / totalcases;
+    var passed_ratio = safeRatio(totalcases, passedcases);
     var current_score = 0;
 
     switch (difficulty) {
@@ -42,20 +90,26 @@ export const ScoreRound1 = (time_left, totalcases, passedcases, difficulty, win,
             total_time = 25 * 60; //25 mins
             max_score = 400;
             break;
+        default:
+            return 0;
     }
+
     current_score += (max_score * 0.3 * passed_ratio);
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
-        if (submits <= 3) {
-            current_score += (max_score * 0.1);
+
+    var bonus = bonusFactor(passed_ratio);
+    if (bonus > 0) {
+        if (submits <= R12_FREE_SUBMITS) {
+            current_score += (max_score * 0.1 * bonus);
         }
-        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        var elapsed = Math.min(total_time, Math.max(0, total_time - time_left));
+        var time_formula = max_score * 0.2 * bonus * Math.exp(-TIME_DECAY_RATE * elapsed);
         current_score += time_formula;
     }
 
-    return current_score;
+    return Math.max(0, current_score);
 };
 
 //1200 maxx
@@ -67,7 +121,7 @@ export const ScoreRound2 = (time_left, totalcases, passedcases, difficulty, win,
     //time - 20%
     var total_time = 0;
     var max_score = 0;
-    var passed_ratio = passedcases / totalcases;
+    var passed_ratio = safeRatio(totalcases, passedcases);
     var current_score = 0;
 
     total_time = 20 * 60; //20 mins
@@ -78,13 +132,17 @@ export const ScoreRound2 = (time_left, totalcases, passedcases, difficulty, win,
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
-        if (submits <= 3) {
-            current_score += (max_score * 0.1);
+
+    var bonus = bonusFactor(passed_ratio);
+    if (bonus > 0) {
+        if (submits <= R12_FREE_SUBMITS) {
+            current_score += (max_score * 0.1 * bonus);
         }
-        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        var elapsed = Math.min(total_time, Math.max(0, total_time - time_left));
+        var time_formula = max_score * 0.2 * bonus * Math.exp(-TIME_DECAY_RATE * elapsed);
         current_score += time_formula;
     }
+
     if (iselite) {
         current_score *= 0.75;
     }
@@ -92,51 +150,72 @@ export const ScoreRound2 = (time_left, totalcases, passedcases, difficulty, win,
         current_score *= 1.25;
     }
 
-    return current_score;
+    return Math.max(0, current_score);
 };
 
 
 
 export const ScoreRound3 = (totalcases, passedcases, submits) => {
-    var score = 0;
-    var passed_ratio = passedcases / totalcases;
-    if (passed_ratio == 1) {
-        score += 600;
-    }
-    else {
-        score += 400 * passed_ratio;
+    var passed_ratio = safeRatio(totalcases, passedcases);
+
+    // Was: ratio === 1 ? 600 : 400 * ratio -- a 204 point (51%) jump for the
+    // last test case, the largest cliff in the event. Same 600 max, but the
+    // gap between "nearly there" and "done" is now proportional.
+    var score = 500 * passed_ratio;
+    if (passed_ratio === 1) {
+        score += 100;
     }
 
-    return score;
+    return Math.max(0, score);
 
     // you lose 100 points if you get hacked
     // gain 100 points if you hack someone elses code
+    // NOTE: not implemented. HackAttempt rows are created by
+    // round3.handler.js but never reviewed, and emitHackResult() is never
+    // called, so hacking currently awards nothing either way.
 
 };
 
-export const ScoreBounty = (difficulty, submits, isSolved) => {
-    var score = 0;
+export const ScoreBounty = (difficulty, submits, totalcases, passedcases) => {
+    var passed_ratio = safeRatio(totalcases, passedcases);
+
+    var base = 0;
     switch (difficulty) {
         case "EASY":
-            score = 100;
+            base = 100;
             break;
         case "MEDIUM":
-            score = 150;
+            base = 150;
             break;
         case "HARD":
-            score = 250;
+            base = 250;
+            break;
+        default:
+            // Fall back to MEDIUM rather than silently scoring 0. The route
+            // currently hardcodes "MEDIUM" because the schema only has a
+            // single R2_BOUNTY difficulty; if that call site ever changes,
+            // an unmapped value should not wipe out everyone's bounty points.
+            base = 150;
             break;
 
     }
-    if (submits > 3) {
-        score = -40;
+
+    // Was: all-or-nothing -- 95% of tests passing scored 0. Every other round
+    // pays partial credit, so bounties now do too. A full solve still pays the
+    // same `base` it always did.
+    var score = base * 0.6 * passed_ratio;
+    if (passed_ratio === 1) {
+        score += base * 0.4;
     }
 
-    if (isSolved) {
-        return score *= 1;
+    // Was: `score = -40`, which OVERWROTE the score -- a correct solution on
+    // attempt 4 scored worse than never attempting. Now it subtracts, and the
+    // result is floored at 0.
+    if (submits > BOUNTY_FREE_SUBMITS) {
+        score -= 20;
     }
 
-    return score;
+    return Math.max(0, score);
 };
 
 // export const Hack = (gothacked) => {

--- a/utils/calculateScore.js
+++ b/utils/calculateScore.js
@@ -1,3 +1,6 @@
+// min passed_ratio required to earn the submit-count/time bonuses in Round 1 & 2
+const CORRECTNESS_THRESHOLD = 0.8;
+
 //submits are the number of submits for a particular questions NOT ROUND
 export const ScoreRound0 = (totalcases, passedcases, submits) => {
     var score = 0;
@@ -44,11 +47,13 @@ export const ScoreRound1 = (time_left, totalcases, passedcases, difficulty, win,
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (submits <= 3) {
-        current_score += (max_score * 0.1);
+    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
+        if (submits <= 3) {
+            current_score += (max_score * 0.1);
+        }
+        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        current_score += time_formula;
     }
-    var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
-    current_score += time_formula;
 
     return current_score;
 };
@@ -73,11 +78,13 @@ export const ScoreRound2 = (time_left, totalcases, passedcases, difficulty, win,
     if (win) {
         current_score += (max_score * 0.4);
     }
-    if (submits <= 3) {
-        current_score += (max_score * 0.1);
+    if (passed_ratio >= CORRECTNESS_THRESHOLD) {
+        if (submits <= 3) {
+            current_score += (max_score * 0.1);
+        }
+        var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
+        current_score += time_formula;
     }
-    var time_formula = max_score * 0.2 * Math.exp(-0.00256 * (total_time - time_left));
-    current_score += time_formula;
     if (iselite) {
         current_score *= 0.75;
     }


### PR DESCRIPTION
## Description

Fixes critical scoring logic issues and adds safeguards.

**Correctness fixes:**
- Judge0 status resolution now checks pass count before compile_output/stderr, so compiler warnings and debug output no longer downgrade fully-correct solutions to COMPILATION_ERROR/RUNTIME_ERROR
- `/submit` now requires `Round.status=IN_PROGRESS`; R0/R3 points were previously farmable outside round windows (admin bypass for testing)
- R1/R2 sessions are captured before judging; Judge0 latency no longer causes in-flight submissions to score 0 or fail
- Win bonus is claimed atomically to prevent double-pays on simultaneous solves
- R2 time bonus now reads real match `endTime` instead of hardcoded 0 (restores the intended 20% weight)
- Scores rounded before persistence; `eventScore` decrements floored at 0

**Fairness for first-years:**
- 0.8 correctness threshold was a ~30% cliff; now ramps linearly from 0.5
- R0/R3 100% cliffs softened (proportional + completion bonus, same maxima)
- Bounties now pay partial credit (was 0 for 95% correct)
- Submit penalties reduced and recoverable; R1 time decay half-life doubled (14.4min)

**Testing:** 56 new tests (scoring formulas + route logic + session validation), all passing. Read-only preflight data check for event day. No new dependencies.

---

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

---

## Related Issues

Scoring audit for IEEE BattleCode event

---

## Checklist

- [x] Code follows project guidelines
- [x] No secrets committed (`.env` ignored)
- [x] Tests added and passing (56/56)
- [x] Tested locally with `npm test`
- [x] Pre-flight data check added (`npm run preflight`)

**Note for reviewers:** After merge, a round left at `COMPLETED` blocks all submissions. Ensure admins know to set `IN_PROGRESS` before the round opens.